### PR TITLE
Post-Splittening Linux Bugfix + Maintenance

### DIFF
--- a/FFTStreamHandlerFields.cs
+++ b/FFTStreamHandlerFields.cs
@@ -1,7 +1,6 @@
 using FrooxEngine;
 using Elements.Assets;
 using CSCore.DSP;
-using Elements.Core;
 
 namespace Resonance;
 

--- a/Resonance.cs
+++ b/Resonance.cs
@@ -39,8 +39,9 @@ public partial class Resonance : ResoniteMod
                 //44100;
                 int sampleRate;
 
-                // Check if we're on Linux.
-                if (!Engine.Current.UseWineRenderer)
+                // Check if we're using SDL. Either non-Windows platform or ForceSDLAudio launch argument
+                Type? audioInputType = __instance.AudioSystem.DefaultAudioInput.GetType();
+                if (audioInputType.Name != "SDLRecordingDevice")
                 {
                     sampleRate = index > 0 ? __instance.AudioSystem.AudioInputs[index].SampleRate : __instance.AudioSystem.DefaultAudioInput.SampleRate;
                 }
@@ -49,7 +50,6 @@ public partial class Resonance : ResoniteMod
                     // We need to cast AudioInput to SDLRecordingDevice to get Format.spec.Freq and set sampleRate.
                     Resonance.Msg("AudioInput is actually SDLRecordingDevice on Linux. Casting and getting sample rate...");
 
-                    Type? audioInputType = __instance.AudioSystem.DefaultAudioInput.GetType();
                     var selectedInput = index > 0 ? __instance.AudioSystem.AudioInputs[index] : __instance.AudioSystem.DefaultAudioInput;
 
                     ValueTuple<SDL3.SDL.AudioSpec, int> sdlRecordingDevice_Format =

--- a/Resonance.cs
+++ b/Resonance.cs
@@ -33,14 +33,19 @@ public partial class Resonance : ResoniteMod
                 return;
 
 
-            __instance.RunSynchronously(() => {
+            __instance.RunSynchronously(() =>
+            {
                 int index = __instance.TargetDeviceIndex ?? -1;
-                
+
                 //44100;
                 int sampleRate;
 
                 // Check if we're using SDL. Either non-Windows platform or ForceSDLAudio launch argument
-                Type? audioInputType = __instance.AudioSystem.DefaultAudioInput.GetType();
+                // Filter out Steam Voice as a special case. Unless it's the only and Default option somehow.
+                Type? audioInputType = __instance.AudioSystem.AudioInputCount > 1 ?
+                        __instance.AudioSystem.AudioInputs.First(ain => ain.DeviceID != "SteamVoice").GetType() :
+                        __instance.AudioSystem.DefaultAudioInput.GetType();
+
                 if (audioInputType.Name != "SDLRecordingDevice")
                 {
                     sampleRate = index > 0 ? __instance.AudioSystem.AudioInputs[index].SampleRate : __instance.AudioSystem.DefaultAudioInput.SampleRate;
@@ -55,7 +60,7 @@ public partial class Resonance : ResoniteMod
                     ValueTuple<SDL3.SDL.AudioSpec, int> sdlRecordingDevice_Format =
                         (ValueTuple<SDL3.SDL.AudioSpec, int>)audioInputType.GetProperty("Format").GetValue(selectedInput);
 
-                    sampleRate =  sdlRecordingDevice_Format.Item1.Freq;
+                    sampleRate = sdlRecordingDevice_Format.Item1.Freq;
                 }
 
                 FFTStreamSettings settings =
@@ -72,7 +77,7 @@ public partial class Resonance : ResoniteMod
                         AutoGain,
                         Quantize_Bins
                     );
-                
+
 
                 FFTStreamHandler streamHandler = new(__instance, settings);
                 streamHandler.Setup();
@@ -84,7 +89,7 @@ public partial class Resonance : ResoniteMod
                 {
                     audioStream.BufferSize.Value = 12000;
                     audioStream.MinimumBufferDelay.Value = 0.05f;
-                } 
+                }
 
                 __instance.Destroyed += FFTStreamHandler.Destroy;
             });
@@ -97,7 +102,7 @@ public partial class Resonance : ResoniteMod
             var world = __instance.World;
             if (world.Focus != World.WorldFocus.Focused || __instance.LocalUser.IsSilenced || (ContactsDialog.RecordingVoiceMessage && ___lastDeviceIndex == __instance.AudioSystem.DefaultAudioInputIndex))
                 return;
-            
+
             if (FFTStreamHandler.FFTDict.TryGetValue(__instance, out FFTStreamHandler handler))
                 handler.UpdateFFTData(buffer);
         }

--- a/Resonance.cs
+++ b/Resonance.cs
@@ -36,8 +36,28 @@ public partial class Resonance : ResoniteMod
             __instance.RunSynchronously(() => {
                 int index = __instance.TargetDeviceIndex ?? -1;
                 
-                int sampleRate = index > 0 ? __instance.AudioSystem.AudioInputs[index].SampleRate : __instance.AudioSystem.DefaultAudioInput.SampleRate;
-                
+                //44100;
+                int sampleRate;
+
+                // Check if we're on Linux.
+                if (!Engine.Current.UseWineRenderer)
+                {
+                    sampleRate = index > 0 ? __instance.AudioSystem.AudioInputs[index].SampleRate : __instance.AudioSystem.DefaultAudioInput.SampleRate;
+                }
+                else
+                {
+                    // We need to cast AudioInput to SDLRecordingDevice to get Format.spec.Freq and set sampleRate.
+                    Resonance.Msg("AudioInput is actually SDLRecordingDevice on Linux. Casting and getting sample rate...");
+
+                    Type? audioInputType = __instance.AudioSystem.DefaultAudioInput.GetType();
+                    var selectedInput = index > 0 ? __instance.AudioSystem.AudioInputs[index] : __instance.AudioSystem.DefaultAudioInput;
+
+                    ValueTuple<SDL3.SDL.AudioSpec, int> sdlRecordingDevice_Format =
+                        (ValueTuple<SDL3.SDL.AudioSpec, int>)audioInputType.GetProperty("Format").GetValue(selectedInput);
+
+                    sampleRate =  sdlRecordingDevice_Format.Item1.Freq;
+                }
+
                 FFTStreamSettings settings =
                     new
                     (

--- a/Resonance.csproj
+++ b/Resonance.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <Authors>Cyro</Authors>
     <Product>Resonance FFT</Product>

--- a/Resonance.csproj
+++ b/Resonance.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net9</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Version>1.0.3</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <Authors>Cyro</Authors>
@@ -13,8 +13,12 @@
     <Copyright>Copyright (c) 2023 Riley Fields</Copyright>
   </PropertyGroup>
 
+  <!--This will test for the default Steam installation paths for Resonite on Windows and Linux.-->
   <PropertyGroup Condition="'$(ResonitePath)'==''">
-    <ResonitePath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
+    <ResonitePath Condition="'$(OS)' == 'Windows_NT' and Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
+    <ResonitePath Condition="'$(OS)' != 'Windows_NT' and Exists('$(HOME)/.local/share/Steam/steamapps/common/Resonite/')">$(HOME)/.local/share/Steam/steamapps/common/Resonite/</ResonitePath>
+    <!--If neither path above exists, you can define your custom Resonite install directory here -->
+    <ResonitePath Condition="'$(ResonitePath)'==''">/Custom/Resonite/Install/Path</ResonitePath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,16 +31,19 @@
       <HintPath Condition="Exists('$(ResonitePath)Libraries\0Harmony.dll')">$(ResonitePath)Libraries\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="FrooxEngine">
-      <HintPath>$(ResonitePath)Resonite_Data\Managed\FrooxEngine.dll</HintPath>
+      <HintPath>$(ResonitePath)FrooxEngine.dll</HintPath>
     </Reference>
     <Reference Include="Elements.Core">
-      <HintPath>$(ResonitePath)Resonite_Data\Managed\Elements.Core.dll</HintPath>
+      <HintPath>$(ResonitePath)Elements.Core.dll</HintPath>
     </Reference>
     <Reference Include="Elements.Assets">
-      <HintPath>$(ResonitePath)Resonite_Data\Managed\Elements.Assets.dll</HintPath>
+      <HintPath>$(ResonitePath)Elements.Assets.dll</HintPath>
     </Reference>
     <Reference Include="CSCore">
-      <HintPath>$(ResonitePath)Resonite_Data\Managed\CSCore.dll</HintPath>
+      <HintPath>$(ResonitePath)CSCore.dll</HintPath>
+    </Reference>
+    <Reference Include="SDL3">
+      <HintPath>$(ResonitePath)SDL3-CS.dll</HintPath>
     </Reference>
   </ItemGroup>
 
@@ -44,8 +51,4 @@
     <!--Copy SourceFiles="$(OutDir)$(TargetFileName)" DestinationFolder="$(ResonitePath)rml_mods" ContinueOnError="true" /-->
     <Copy SourceFiles="$(OutDir)$(TargetFileName)" DestinationFolder="$(OutDir)Result" ContinueOnError="true" />
   </Target>
-
-  <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Bugfix
This PR fixes a bug where the `sampleRate` is set to `0` when creating a new instance of `FFTStreamSettings`. This is because `SDLRecordingDevice` is a child of `AudioInput`, but its inherited `SampleRate` property never appears to get set.

When on using SDL, I treat `FrooxEngine.AudioInput` objects from `FrooxEngine.AudioSystem.AudioInputs` as `FrooxEngine.SDLRecordingDevice` so we can retrieve the sample rate from `FrooxEngine.SDLRecordingDevice.Format`.

## Maintenance
- Bumped runtime to `net9`
- Changed LangVersion to `latest` (we can revert if `preview` still needed)
- Added more robust OS-aware path selection from newer csproj templates
- Changed Reference Library paths to reflect new post-splittening paths
- Added SDL3-CS reference
- Removed `System.Memory` package reference as this is now included in newer .NET releases
- Removed a stray reference in `FFTStreamHandlerFields.cs`